### PR TITLE
Fix missing transparent.png at runtime

### DIFF
--- a/ask-server/ask-client.py
+++ b/ask-server/ask-client.py
@@ -9,6 +9,7 @@ from markdown import markdown
 from html.parser import HTMLParser
 from dotenv import load_dotenv
 from tkinter import font
+from PIL import Image
 
 load_dotenv()
 
@@ -901,6 +902,9 @@ class ChatApp(tk.Tk):
             
             # Custom button styling for Windows dark mode
             if os.name == 'nt':
+                if not os.path.isfile('transparent.png'):
+                    img = Image.new('RGBA', (1, 1), (0, 0, 0, 0))
+                    img.save('transparent.png')
                 img = tk.PhotoImage(file='transparent.png')
                 s.element_create('Dark.TButton.photo', 'image', img, sticky='ew')
                 s.layout('Dark.TButton', [('Dark.TButton.photo', {'children': [('Button.padding', {'children': [('Button.label', {'side': 'left', 'expand': 1})]})]})])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+python-dotenv
+markdown
+pillow
+openai
+selenium


### PR DESCRIPTION
## Summary
- create placeholder PNG image when `transparent.png` is missing
- import `Image` from PIL for PNG generation
- list Python dependencies in `requirements.txt`

## Testing
- `python3 -m py_compile ask-server/ask-client.py`
- `bash ask-server/ask-test.sh` *(fails: can't open file 'ask.py')*

------
https://chatgpt.com/codex/tasks/task_e_687153833fd4832d9819ea3df9c97603