### PR TITLE
Fix RAG file/url persistence and context retrieval

### DIFF
--- a/ask-server/ask-client.py
+++ b/ask-server/ask-client.py
@@ -28,13 +28,23 @@ def initialize_rag():
     # Default to 'true' if setting doesn't exist
     if get_setting("enable_rag", "true") == "True":
         try:
-            from rag.rag import get_rag_processor, add_url_to_chat, delete_url_from_chat,  add_file_to_chat, get_files_for_chat, delete_file_from_chat, query_by_chat_id
+            from rag.rag import (
+                get_rag_processor,
+                add_url_to_chat,
+                delete_url_from_chat,
+                add_file_to_chat,
+                get_files_for_chat,
+                get_urls_for_chat,
+                delete_file_from_chat,
+                query_by_chat_id,
+            )
             # Initialize the processor to trigger model loading
             get_rag_processor() 
             # Store functions for later use
             rag_functions['add_file_to_chat'] = add_file_to_chat
             rag_functions["add_url_to_chat"] = add_url_to_chat
             rag_functions['get_files_for_chat'] = get_files_for_chat
+            rag_functions['get_urls_for_chat'] = get_urls_for_chat
             rag_functions['delete_file_from_chat'] = delete_file_from_chat
             rag_functions['delete_url_from_chat'] = delete_url_from_chat
             rag_functions['query_by_chat_id'] = query_by_chat_id
@@ -1555,8 +1565,10 @@ class ChatApp(tk.Tk):
 
                 if rag_functions:
                     self.chat_files = rag_functions['get_files_for_chat'](self.session_id)
+                    self.chat_urls = rag_functions['get_urls_for_chat'](self.session_id)
                 else:
                     self.chat_files = []
+                    self.chat_urls = []
                 self.load_chat_history()
                 self.message_history = get_input_history(self.session_id)
                 self.history_index = len(self.message_history)
@@ -1731,9 +1743,9 @@ class ChatApp(tk.Tk):
         if system_prompt:
             message_blocks.insert(0, {"role": "system", "content": system_prompt})
 
-        # RAG workflow: If chat has associated files, retrieve context from ChromaDB
+        # RAG workflow: If chat has associated resources, retrieve context from ChromaDB
         context_block = None
-        if rag_functions and self.chat_files:
+        if rag_functions and (self.chat_files or self.chat_urls):
             try:
                 # Embed query and retrieve top-K relevant chunks
                 top_k = 5
@@ -2140,9 +2152,9 @@ class ChatApp(tk.Tk):
         if system_prompt:
             message_blocks.insert(0, {"role": "system", "content": system_prompt})
 
-        # RAG workflow: If chat has associated files, retrieve context from ChromaDB
+        # RAG workflow: If chat has associated resources, retrieve context from ChromaDB
         context_block = None
-        if rag_functions and self.chat_files:
+        if rag_functions and (self.chat_files or self.chat_urls):
             try:
                 top_k = 5
                 rag_results = rag_functions['query_by_chat_id'](self.session_id, content, n_results=top_k)

--- a/ask-server/rag/rag.py
+++ b/ask-server/rag/rag.py
@@ -153,7 +153,7 @@ def delete_file_from_chat(filepath, chat_id=None):
 def delete_url_from_chat(url, chat_id=None):
     rag_processor = get_rag_processor()
     results = rag_processor.collection.get(where={"chat_id": chat_id})
-    ids = [id_ for id_, meta in zip(results["ids"], results["metadatas"]) if meta.get("source") == simple_url_id(url)]
+    ids = [id_ for id_, meta in zip(results["ids"], results["metadatas"]) if meta.get("source") == url]
     if ids:
         rag_processor.collection.delete(ids=ids)
         print(f"Deleted {len(ids)} chunks for URL '{URL}' in chat '{chat_id}' from ChromaDB.")
@@ -199,6 +199,16 @@ def get_files_for_chat(chat_id: str):
     unique_files = {meta['source'] for meta in results["metadatas"] if 'source' in meta}
     
     return list(unique_files)
+
+def get_urls_for_chat(chat_id: str):
+    if not chat_id:
+        return []
+    results = get_rag_processor().collection.get(where={"chat_id": chat_id})
+
+    if not results or not results.get("metadatas"):
+        return []
+
+    return [meta['source'] for meta in results["metadatas"] if meta.get("url")]
 
 def simple_url_id(url: str) -> str:
     """
@@ -266,4 +276,13 @@ def main():
 if __name__ == "__main__":
     main()
 
-__all__ = ["query_by_chat_id", "add_file_to_chat", "add_url_to_chat", "delete_file_from_chat", "delete_url_from_chat", "get_files_for_chat", "delete_all_files_from_chat"]
+__all__ = [
+    "query_by_chat_id",
+    "add_file_to_chat",
+    "add_url_to_chat",
+    "delete_file_from_chat",
+    "delete_url_from_chat",
+    "get_files_for_chat",
+    "delete_all_files_from_chat",
+    "get_urls_for_chat",
+]


### PR DESCRIPTION
## Summary
- hook up retrieval of URL resources from ChromaDB
- load URL list when a chat session is selected
- use files or URLs for building context in prompts
- fix deleting URL chunks in ChromaDB

## Testing
- `python -m py_compile ask-server/ask-client.py ask-server/rag/rag.py`
- `python ask-server/ask-client.py --help` *(fails: ModuleNotFoundError: No module named 'markdown')*

------
https://chatgpt.com/codex/tasks/task_e_687cfef084c8832dacf737f9176dc732