### PR TITLE
Add optional HTTPS for ask-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,34 @@ You can quickly deploy the proxy server to [Render.com](https://render.com), a p
 
 Once deployed, point your SlipstreamAI client to the new proxy server URL for remote access.
 
+### Enabling HTTPS
+
+`ask-server.js` can optionally run over HTTPS. Provide the paths to your SSL key and certificate via the `SSL_KEY_PATH` and `SSL_CERT_PATH` environment variables. If both are set, the server will listen with TLS enabled.
+
+#### Self‑signed certificate
+
+For local testing you can generate a self‑signed certificate:
+
+```bash
+openssl req -x509 -newkey rsa:4096 -nodes -keyout key.pem -out cert.pem -days 365
+```
+
+Set the variables and start the server:
+
+```bash
+export SSL_KEY_PATH=$(pwd)/key.pem
+export SSL_CERT_PATH=$(pwd)/cert.pem
+node ask-server.js
+```
+
+#### Using a real certificate
+
+On a public server you can obtain a free certificate from [Let’s Encrypt](https://letsencrypt.org/). Tools like [Certbot](https://certbot.eff.org/) automate the process:
+
+```bash
+sudo certbot certonly --standalone -d yourdomain.com
+```
+
+After issuance, set `SSL_KEY_PATH` to the private key file and `SSL_CERT_PATH` to the full chain certificate provided by Certbot. Restart `ask-server.js` and update your client’s `OPENAI_PROXY_URL` to use `https://`.
+
 ---

--- a/ask-server/ask-server.js
+++ b/ask-server/ask-server.js
@@ -2,6 +2,8 @@ import express from 'express'
 import cors from 'cors'
 import dotenv from 'dotenv'
 import fetch from 'node-fetch'
+import https from 'https'
+import fs from 'fs'
 
 dotenv.config()
 
@@ -9,6 +11,8 @@ const app = express()
 const PORT = process.env.PORT || 3000
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY
 const API_SECRET_TOKEN = process.env.API_SECRET_TOKEN
+const SSL_KEY_PATH = process.env.SSL_KEY_PATH
+const SSL_CERT_PATH = process.env.SSL_CERT_PATH
 
 if (!OPENAI_API_KEY || !API_SECRET_TOKEN) {
   console.error('❌ Missing OPENAI_API_KEY or API_SECRET_TOKEN in .env')
@@ -111,7 +115,17 @@ app.post('/v1/chat/completions', async (req, res) => {
   }
 })
 
-app.listen(PORT, () => {
-  console.log(`🚀 Proxy running with streaming at http://localhost:${PORT}`)
-})
+if (SSL_KEY_PATH && SSL_CERT_PATH) {
+  const httpsOptions = {
+    key: fs.readFileSync(SSL_KEY_PATH),
+    cert: fs.readFileSync(SSL_CERT_PATH)
+  }
+  https.createServer(httpsOptions, app).listen(PORT, () => {
+    console.log(`🚀 HTTPS Proxy running with streaming at https://localhost:${PORT}`)
+  })
+} else {
+  app.listen(PORT, () => {
+    console.log(`🚀 Proxy running with streaming at http://localhost:${PORT}`)
+  })
+}
 


### PR DESCRIPTION
## Summary
- update `ask-server.js` to support HTTPS when `SSL_KEY_PATH` and `SSL_CERT_PATH` are set
- document how to run the server with self‑signed or real certificates

## Testing
- `node --check ask-server/ask-server.js`
- `npm install --silent` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_687e50fcf654832d98f5d4200e3409c5