### PR TITLE
Remove RAG auto unload and refresh file list

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,4 @@ API_SECRET_TOKEN=your-made-up-key-that-matches-server
 #PORT=3001
 PUBLISHED_API=https://localhost:3000
 PROXY_VERIFY_CERT=False
-# Time in minutes before the RAG model is unloaded when idle
-RAG_IDLE_MINUTES=1
 


### PR DESCRIPTION
## Summary
- drop unused `RAG_IDLE_MINUTES` env var
- remove logic that unloaded the RAG processor after a timeout
- refresh the files list when chats or folders are selected
- clean up `.env.sample`

## Testing
- `python -m py_compile ask-server/ask-client.py ask-server/rag/rag.py rag_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_68876a7726b8832db20d3fc79b789904