### PR TITLE
Fix ChromaDB persistence

### DIFF
--- a/ask-server/rag/rag_manager.py
+++ b/ask-server/rag/rag_manager.py
@@ -12,10 +12,9 @@ class RAGManager:
         """Load (or reload) the ChromaDB database from ``persist_directory``."""
         self.close()
         
-        #self.client = chromadb.PersistentClient(
-        #    Settings(chroma_db_impl="duckdb+parquet", persist_directory=persist_directory)
-        #)
-        self.client = chromadb.Client()
+        self.client = chromadb.PersistentClient(
+            Settings(chroma_db_impl="duckdb+parquet", persist_directory=persist_directory)
+        )
         self.collection = self.client.get_or_create_collection("rag")
         return self.collection
 


### PR DESCRIPTION
## Summary
- store RAG files with `PersistentClient` instead of in-memory client

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68876fffb80c832dba0135afe3b9baa6